### PR TITLE
chore: fix float_term cmd type to allow args

### DIFF
--- a/.config/nvim/lua/float_term.lua
+++ b/.config/nvim/lua/float_term.lua
@@ -4,7 +4,7 @@ local M = {}
 local terminal = nil
 
 --- Opens an interactive floating terminal.
----@param cmd? string
+---@param cmd? string[]|string
 ---@param opts? LazyCmdOptions
 function M.float_term(cmd, opts)
     opts = vim.tbl_deep_extend('force', {


### PR DESCRIPTION
[`lazy.util.float_term` allows `cmd` to be an array](https://github.com/folke/lazy.nvim/blob/main/lua/lazy/util.lua#L135) so that you can run a command with args.

e.g. this allowed me to change a keymap to run `tig status` instead of just `tig`

```diff
                 vim.keymap.set('n', '<leader>gt', function()
-                    require('float_term').float_term('tig', {
+                    require('float_term').float_term({ 'tig', 'status' }, {
                         size = { width = 0.85, height = 0.8 },
                         cwd = vim.b.gitsigns_status_dict.root,
                     })
-                end, { desc = 'tig' })
+                end, { desc = 'tig status' })
```