### PR TITLE
fix(winbar): support special characters in special_dirs

### DIFF
--- a/.config/nvim/lua/winbar.lua
+++ b/.config/nvim/lua/winbar.lua
@@ -39,7 +39,7 @@ function M.render()
             end
         end
         if prefix ~= '' then
-            path = path:gsub('^' .. prefix_path, '')
+            path = path:gsub('^' .. vim.pesc(prefix_path), '')
             prefix = string.format('%%#WinBarDir#%s %s%s', folder_icon, prefix, separator)
         end
     end


### PR DESCRIPTION
## Problem
The winbar was not correctly abbreviating paths for the CN directory. While DOTFILES paths displayed correctly as "DOTFILES > ...", CN paths showed the full path "CN > Users > coreycole > cn > chestnut-flake > monorepo > ..." instead of just "CN > ...".

## Root Cause
The `gsub` function on line 39 was using `prefix_path` directly as a pattern without escaping special regex characters. The path `/Users/coreycole/cn/chestnut-flake/monorepo` contains hyphens which have special meaning in Lua patterns, causing the pattern match to fail.

## Solution
Wrapped `prefix_path` with `vim.pesc()` to escape all special pattern characters, ensuring the path is treated as a literal string for replacement.

## Changes
- Changed `path:gsub("^" .. prefix_path, "")` to `path:gsub("^" .. vim.pesc(prefix_path), "")`